### PR TITLE
Fix missing Supabase config checks

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -98,6 +98,10 @@ export function useAuth() {
   };
 
   const signIn = async (email: string, password: string) => {
+    if (!isSupabaseConfigured) {
+      return { error: new Error('Supabase not configured') };
+    }
+
     try {
       const { error } = await supabase.auth.signInWithPassword({
         email,
@@ -110,12 +114,16 @@ export function useAuth() {
   };
 
   const signUp = async (email: string, password: string) => {
+    if (!isSupabaseConfigured) {
+      return { error: new Error('Supabase not configured') };
+    }
+
     try {
       const { data, error } = await supabase.auth.signUp({
         email,
         password,
       });
-      
+
       return { error };
     } catch (error) {
       return { error };
@@ -123,6 +131,10 @@ export function useAuth() {
   };
 
   const signOut = async () => {
+    if (!isSupabaseConfigured) {
+      return { error: new Error('Supabase not configured') };
+    }
+
     try {
       const { error } = await supabase.auth.signOut();
       setUser(null);

--- a/src/hooks/useSermons.ts
+++ b/src/hooks/useSermons.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { supabase, Sermon } from '../lib/supabase';
+import { supabase, Sermon, isSupabaseConfigured } from '../lib/supabase';
 import { useAuth } from './useAuth';
 
 export function useSermons() {
@@ -14,7 +14,7 @@ export function useSermons() {
   }, [churchUser]);
 
   const fetchSermons = async () => {
-    if (!churchUser?.church_id) return;
+    if (!isSupabaseConfigured || !churchUser?.church_id) return;
 
     try {
       setLoading(true);
@@ -43,6 +43,9 @@ export function useSermons() {
     youtube_url: string;
     series_name?: string;
   }) => {
+    if (!isSupabaseConfigured) {
+      throw new Error('Supabase not configured');
+    }
     if (!churchUser?.church_id) throw new Error('No church selected');
 
     const { data, error } = await supabase
@@ -69,6 +72,10 @@ export function useSermons() {
   };
 
   const updateSermon = async (id: string, updates: Partial<Sermon>) => {
+    if (!isSupabaseConfigured) {
+      throw new Error('Supabase not configured');
+    }
+
     const { error } = await supabase
       .from('sermons')
       .update(updates)
@@ -79,6 +86,10 @@ export function useSermons() {
   };
 
   const deleteSermon = async (id: string) => {
+    if (!isSupabaseConfigured) {
+      throw new Error('Supabase not configured');
+    }
+
     const { error } = await supabase
       .from('sermons')
       .delete()


### PR DESCRIPTION
## Summary
- avoid runtime errors when Supabase env vars are missing
- bail out early in `useSermons` CRUD helpers

## Testing
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_687296e1b97c8321843ade892454e658