### PR TITLE
Ensure env variables load correctly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Toaster } from 'react-hot-toast';
+import { env } from './lib/env';
 
 function App() {
   const [activeTab, setActiveTab] = useState('sermons');
@@ -17,6 +18,8 @@ function App() {
     notionEmbedUrl: 'https://www.notion.so/embed/your-church-content-hub-url'
   };
 
+  const n8nWebhookUrl = env.n8nWebhookUrl;
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     
@@ -25,8 +28,10 @@ function App() {
       return;
     }
 
-    // Your actual n8n webhook URL
-    const n8nWebhookUrl = 'https://79jn2mpy.rpcl.app/webhook-test/church-seo-intake';
+    if (!n8nWebhookUrl) {
+      alert('Webhook URL is not configured');
+      return;
+    }
     
     const sermonData = {
       churchId: currentChurch.id,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,12 @@
+export const env = {
+  n8nWebhookUrl: import.meta.env.VITE_N8N_WEBHOOK_URL as string | undefined,
+  supabaseUrl: import.meta.env.VITE_SUPABASE_URL as string | undefined,
+  supabaseAnonKey: import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined,
+};
+
+if (!env.n8nWebhookUrl) {
+  console.warn('VITE_N8N_WEBHOOK_URL is not defined');
+}
+if (!env.supabaseUrl || !env.supabaseAnonKey) {
+  console.warn('Supabase environment variables are not fully configured');
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
+import { env } from './env';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = env.supabaseUrl;
+const supabaseAnonKey = env.supabaseAnonKey;
 
 // Check if Supabase is configured
 export const isSupabaseConfigured = !!(supabaseUrl && supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add env helper to load `import.meta.env` variables safely
- use the new env helper in `App.tsx`
- connect Supabase to env helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68729c99bf9483219eb1905ec39eef96