### PR TITLE
Improve fetch error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Church SEO Dashboard
+
+This project is a small demo showing how a church can submit sermons and view generated content.  It uses React with Supabase for data storage and authentication.
+
+## Environment Setup
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+   (If your environment does not have internet access you may need to pre-load `node_modules`.)
+
+2. **Create a `.env` file**
+   ```bash
+   cp .env.example .env
+   ```
+   Fill in `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` for your Supabase project.  The example values point to a demo project.
+
+3. **Run database migrations**
+   The `supabase/migrations` folder contains SQL scripts that create the following tables:
+   - `churches`
+   - `church_users`
+   - `sermons`
+   - `sermon_content`
+
+   You can apply them with the Supabase CLI:
+   ```bash
+   npx supabase db reset --local
+   ```
+   or through the Supabase dashboard by running each script manually.
+
+## Creating Church Users
+
+Authentication uses Supabase Auth.  Accounts can be created in two ways:
+
+1. **Via the Supabase Dashboard** – navigate to **Authentication → Users** and create a new user with an email and password.
+2. **Via the sign up option on the login screen** – users can self‑register if you leave sign up enabled.
+
+After a user is created you must insert a record into the `church_users` table linking the user to a church.  An example SQL snippet:
+```sql
+INSERT INTO church_users (church_id, user_id, role)
+VALUES ('<church uuid>', '<auth user id>', 'admin');
+```
+
+Once linked, the user can log in and will only see data for their own church.
+
+## Running the App
+
+```bash
+npm run dev
+```
+
+The sermon submission form and Content Hub work the same as before, but they are now protected by authentication.  An admin user can access `/admin` to manage church records and reset passwords.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,38 +1,59 @@
 import React, { useState } from 'react';
+import { Routes, Route, Navigate, Link } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
+import { LoginForm } from './components/Auth/LoginForm';
+import { useAuth } from './hooks/useAuth';
+import { NotionEmbed } from './components/NotionEmbed';
+import { AdminPortal } from './pages/Admin/AdminPortal';
 import { env } from './lib/env';
 
-function App() {
+function Protected({ children }: { children: React.ReactElement }) {
+  const { user, loading, fetchError } = useAuth();
+  if (loading) {
+    return <div className="p-8">Fetching church user...</div>;
+  }
+  if (fetchError) {
+    return (
+      <div className="p-8 text-red-600">
+        Error loading church account: {fetchError}
+      </div>
+    );
+  }
+  return user ? children : <Navigate to="/login" replace />;
+}
+
+function AdminRoute({ children }: { children: React.ReactElement }) {
+  const { user } = useAuth();
+  const isAdmin = user?.user_metadata?.is_admin;
+  return isAdmin ? children : <Navigate to="/" replace />;
+}
+
+function Home() {
+  const { churchUser, signOut, user } = useAuth();
   const [activeTab, setActiveTab] = useState('sermons');
   const [formData, setFormData] = useState({
     sermonUrl: '',
     sermonDate: '',
     speakerName: '',
-    sermonTitle: ''
+    sermonTitle: '',
   });
 
-  // This would be dynamic per church in production
-  const currentChurch = {
-    id: 'demo-church-123',
-    name: 'Demo Church',
-    notionEmbedUrl: 'https://www.notion.so/embed/your-church-content-hub-url'
-  };
-
   const n8nWebhookUrl = env.n8nWebhookUrl;
+  const currentChurch = churchUser?.church;
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!formData.sermonUrl || !formData.sermonDate || !formData.speakerName) {
       alert('Please fill in all required fields');
       return;
     }
 
-    if (!n8nWebhookUrl) {
-      alert('Webhook URL is not configured');
+    if (!n8nWebhookUrl || !currentChurch) {
+      alert('Configuration missing');
       return;
     }
-    
+
     const sermonData = {
       churchId: currentChurch.id,
       churchName: currentChurch.name,
@@ -40,58 +61,58 @@ function App() {
       sermonDate: formData.sermonDate,
       speakerName: formData.speakerName,
       sermonTitle: formData.sermonTitle,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
 
     try {
-      console.log('Sending to n8n:', sermonData);
-      
       const response = await fetch(n8nWebhookUrl, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(sermonData)
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(sermonData),
       });
 
       if (response.ok) {
         alert('Your sermon has been submitted and your content will be available shortly!');
-        
-        // Reset form
-        setFormData({
-          sermonUrl: '',
-          sermonDate: '',
-          speakerName: '',
-          sermonTitle: ''
-        });
+        setFormData({ sermonUrl: '', sermonDate: '', speakerName: '', sermonTitle: '' });
       } else {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        throw new Error(`HTTP ${response.status}`);
       }
-      
     } catch (error) {
       console.error('Webhook error:', error);
       alert('Failed to submit sermon. Please try again or contact support.');
     }
   };
 
+  if (!currentChurch) {
+    return <div className="p-8">No church assigned to this account.</div>;
+  }
+
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
       <div className="bg-white shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
-            <div className="flex items-center">
+            <div className="flex items-center space-x-3">
               <h1 className="text-xl font-semibold text-gray-800">Church SEO Assistant</h1>
-              <span className="ml-3 px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded font-medium">
+              <span className="px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded font-medium">
                 {currentChurch.name}
               </span>
+            </div>
+            <div className="flex items-center space-x-3 text-sm">
+              {user?.user_metadata?.is_admin && (
+                <Link to="/admin" className="text-blue-600 hover:underline">
+                  Admin Portal
+                </Link>
+              )}
+              <button onClick={() => signOut()} className="text-gray-600 hover:underline">
+                Sign Out
+              </button>
             </div>
           </div>
         </div>
       </div>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Tab Navigation */}
         <div className="mb-8">
           <nav className="flex space-x-8">
             <button
@@ -117,76 +138,60 @@ function App() {
           </nav>
         </div>
 
-        {/* Submit Sermon Tab */}
         {activeTab === 'sermons' && (
           <div className="bg-white rounded-lg shadow-sm p-6">
             <h2 className="text-xl font-semibold text-gray-800 mb-6">Submit New Sermon</h2>
             <p className="text-gray-600 mb-6">
               Submit your sermon details below and we'll automatically generate SEO content, social media posts, and marketing materials for you.
             </p>
-            
+
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Sermon URL *
-                  </label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Sermon URL *</label>
                   <input
                     type="url"
                     value={formData.sermonUrl}
-                    onChange={(e) => setFormData({...formData, sermonUrl: e.target.value})}
+                    onChange={(e) => setFormData({ ...formData, sermonUrl: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                     placeholder="https://youtube.com/watch?v=..."
                     required
                   />
                 </div>
-                
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Sermon Date *
-                  </label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Sermon Date *</label>
                   <input
                     type="date"
                     value={formData.sermonDate}
-                    onChange={(e) => setFormData({...formData, sermonDate: e.target.value})}
+                    onChange={(e) => setFormData({ ...formData, sermonDate: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                     required
                   />
                 </div>
-                
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Speaker Name *
-                  </label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Speaker Name *</label>
                   <input
                     type="text"
                     value={formData.speakerName}
-                    onChange={(e) => setFormData({...formData, speakerName: e.target.value})}
+                    onChange={(e) => setFormData({ ...formData, speakerName: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                     placeholder="Pastor John Smith"
                     required
                   />
                 </div>
-                
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Sermon Title (Optional)
-                  </label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Sermon Title (Optional)</label>
                   <input
                     type="text"
                     value={formData.sermonTitle}
-                    onChange={(e) => setFormData({...formData, sermonTitle: e.target.value})}
+                    onChange={(e) => setFormData({ ...formData, sermonTitle: e.target.value })}
                     className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                     placeholder="Walking in Faith"
                   />
                 </div>
               </div>
-              
               <div className="pt-4">
-                <button
-                  type="submit"
-                  className="bg-indigo-600 text-white px-6 py-3 rounded-md hover:bg-indigo-700 transition-colors flex items-center"
-                >
+                <button type="submit" className="bg-indigo-600 text-white px-6 py-3 rounded-md hover:bg-indigo-700 transition-colors flex items-center">
                   <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
                   </svg>
@@ -205,44 +210,15 @@ function App() {
               </ul>
             </div>
 
-            {/* Debug Info */}
             <div className="mt-4 p-3 bg-gray-100 rounded text-xs text-gray-600">
               <strong>Debug Info:</strong> Webhook URL: {n8nWebhookUrl} | Church ID: {currentChurch.id}
             </div>
           </div>
         )}
 
-        {/* Content Hub Tab */}
         {activeTab === 'content' && (
-          <div className="bg-white rounded-lg shadow-sm">
-            <div className="px-6 py-4 border-b border-gray-200">
-              <h2 className="text-lg font-semibold text-gray-800">Your Content Hub</h2>
-              <p className="text-sm text-gray-600 mt-1">
-                All your generated content organized by sermon. Click any item to view and edit.
-              </p>
-            </div>
-            
-            <div className="p-6">
-              <div className="mb-4 text-sm text-gray-500">
-                Your personalized content database powered by Notion
-              </div>
-              
-              {/* Notion Embed */}
-              <div className="border rounded-lg overflow-hidden" style={{ height: '600px' }}>
-                <iframe
-                  src={currentChurch.notionEmbedUrl}
-                  width="100%"
-                  height="100%"
-                  frameBorder="0"
-                  title="Church Content Hub"
-                  className="w-full h-full"
-                />
-              </div>
-              
-              <div className="mt-4 text-xs text-gray-400">
-                ✨ Content automatically generated by Church SEO Assistant
-              </div>
-            </div>
+          <div className="bg-white rounded-lg shadow-sm p-6">
+            <NotionEmbed />
           </div>
         )}
       </div>
@@ -251,4 +227,28 @@ function App() {
   );
 }
 
-export default App;
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginForm />} />
+      <Route
+        path="/admin"
+        element={
+          <Protected>
+            <AdminRoute>
+              <AdminPortal />
+            </AdminRoute>
+          </Protected>
+        }
+      />
+      <Route
+        path="/*"
+        element={
+          <Protected>
+            <Home />
+          </Protected>
+        }
+      />
+    </Routes>
+  );
+}

--- a/src/hooks/useChurches.ts
+++ b/src/hooks/useChurches.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+import { supabase, Church, isSupabaseConfigured } from '../lib/supabase';
+
+export function useChurches() {
+  const [churches, setChurches] = useState<Church[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchChurches = async () => {
+    if (!isSupabaseConfigured) {
+      setLoading(false);
+      return;
+    }
+    const { data, error } = await supabase
+      .from('churches')
+      .select('*')
+      .order('name');
+    if (error) {
+      console.error('Error fetching churches:', error);
+    }
+    setChurches(data || []);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchChurches();
+  }, []);
+
+  const addChurch = async (church: Partial<Church>) => {
+    if (!isSupabaseConfigured) return;
+    const { error } = await supabase.from('churches').insert(church);
+    if (error) throw error;
+    await fetchChurches();
+  };
+
+  const updateChurch = async (id: string, updates: Partial<Church>) => {
+    if (!isSupabaseConfigured) return;
+    const { error } = await supabase.from('churches').update(updates).eq('id', id);
+    if (error) throw error;
+    await fetchChurches();
+  };
+
+  const deleteChurch = async (id: string) => {
+    if (!isSupabaseConfigured) return;
+    const { error } = await supabase.from('churches').delete().eq('id', id);
+    if (error) throw error;
+    await fetchChurches();
+  };
+
+  return { churches, loading, addChurch, updateChurch, deleteChurch, refetch: fetchChurches };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );

--- a/src/pages/Admin/AdminPortal.tsx
+++ b/src/pages/Admin/AdminPortal.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import { useChurches } from '../../hooks/useChurches';
+import { Church, supabase } from '../../lib/supabase';
+import toast from 'react-hot-toast';
+
+export function AdminPortal() {
+  const { churches, loading, addChurch, updateChurch, deleteChurch } = useChurches();
+  const [editing, setEditing] = useState<Church | null>(null);
+  const [form, setForm] = useState<Partial<Church>>({ name: '', slug: '', contact_email: '', notion_page_url: '' });
+
+  const handleEdit = (church: Church) => {
+    setEditing(church);
+    setForm(church);
+  };
+
+  const handleCancel = () => {
+    setEditing(null);
+    setForm({ name: '', slug: '', contact_email: '', notion_page_url: '' });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (editing) {
+        await updateChurch(editing.id, form);
+        toast.success('Church updated');
+      } else {
+        await addChurch(form);
+        toast.success('Church added');
+      }
+      handleCancel();
+    } catch (err) {
+      toast.error('Operation failed');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete this church?')) return;
+    try {
+      await deleteChurch(id);
+      toast.success('Church deleted');
+    } catch (err) {
+      toast.error('Delete failed');
+    }
+  };
+
+  const handleResetPassword = async (church: Church) => {
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(church.contact_email);
+      if (error) throw error;
+      toast.success('Password reset email sent');
+    } catch (err) {
+      toast.error('Failed to send reset email');
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto py-8 space-y-6">
+      <h1 className="text-2xl font-bold">Admin Portal</h1>
+
+      <form onSubmit={handleSubmit} className="bg-white p-4 rounded-lg space-y-4 border">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <input
+            className="border px-3 py-2 rounded"
+            placeholder="Name"
+            value={form.name || ''}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            required
+          />
+          <input
+            className="border px-3 py-2 rounded"
+            placeholder="Slug"
+            value={form.slug || ''}
+            onChange={(e) => setForm({ ...form, slug: e.target.value })}
+            required
+          />
+          <input
+            className="border px-3 py-2 rounded"
+            placeholder="Contact Email"
+            type="email"
+            value={form.contact_email || ''}
+            onChange={(e) => setForm({ ...form, contact_email: e.target.value })}
+            required
+          />
+          <input
+            className="border px-3 py-2 rounded"
+            placeholder="Notion Page URL"
+            value={form.notion_page_url || ''}
+            onChange={(e) => setForm({ ...form, notion_page_url: e.target.value })}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+            {editing ? 'Update Church' : 'Add Church'}
+          </button>
+          {editing && (
+            <button type="button" onClick={handleCancel} className="px-4 py-2 border rounded">
+              Cancel
+            </button>
+          )}
+        </div>
+      </form>
+
+      <div className="bg-white p-4 rounded-lg border">
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          <table className="w-full text-left">
+            <thead>
+              <tr>
+                <th className="p-2">Name</th>
+                <th className="p-2">Email</th>
+                <th className="p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {churches.map((c) => (
+                <tr key={c.id} className="border-t">
+                  <td className="p-2">{c.name}</td>
+                  <td className="p-2">{c.contact_email}</td>
+                  <td className="p-2 space-x-2">
+                    <button className="text-blue-600" onClick={() => handleEdit(c)}>
+                      Edit
+                    </button>
+                    <button className="text-red-600" onClick={() => handleDelete(c.id)}>
+                      Delete
+                    </button>
+                    <button className="text-gray-600" onClick={() => handleResetPassword(c)}>
+                      Reset Password
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- return better debug info when loading church user from Supabase
- expose any load error through `useAuth`
- surface load errors in the Protected route UI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a178126c8321ae0ede730174aef3